### PR TITLE
Fix empty responses from qa model by skipping it during iteration

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ def ask_question(context, question, language):
             {
                 "text": answer['answer'][i],
                 "confidence": "{:.8f}".format(probability["probability"][i])
-            } for i in range(len(answer['answer']))
+            } for i in range(len(answer['answer'])) if answer['answer'][i] and answer['answer'][i] != 'empty'
         ],
         "id": answer['id']
     }


### PR DESCRIPTION
This is the response when no answer is found after this fix:
```{'answers': [], 'id': '0'}```

When an answer is found, the response is normal:
```
{
  'answers': [{
      'text': 'Nilo',
      'confidence': '0.97685505'
    },
    {
      'text': 'Nilo.',
      'confidence': '0.01377175'
    },
    {
      'text': 'meu nome é Nilo',
      'confidence': '0.00937319'
    }
  ],
  'id': '0'
}
```